### PR TITLE
Fixing ArgumentOutOfRangeException

### DIFF
--- a/Assets/EmojiTexture/EmojiTexture.cs
+++ b/Assets/EmojiTexture/EmojiTexture.cs
@@ -133,7 +133,7 @@ namespace iBicha
                     return 0;
                 if (text.Length == 1)
                     return text[0];
-                return char.ConvertToUtf32(text[0], text[1]);
+                return char.ConvertToUtf32(text, 0);
             }
             set { Text = char.ConvertFromUtf32(value); }
         }


### PR DESCRIPTION
Trying to set TextMesh Pro text to "😂⚽️❤️🔥🤪" gives white-squares-instead-of-emoji result and exception in Xcode output:

```ArgumentOutOfRangeException: Argument is out of range.
Parameter name: highSurrogate
  at System.Char.ConvertToUtf32 (Char highSurrogate, Char lowSurrogate) [0x00000] in <filename unknown>:0 
  at iBicha.TMPro.TMProEmojiAsset.Process (System.String text) [0x00000] in <filename unknown>:0 
  at iBicha.TMPro.TMP_EmojiSupport.OnTextChange (System.Object obj) [0x00000] in <filename unknown>:0 
  at TMPro.FastAction`1[A].Call (.A a) [0x00000] in <filename unknown>:0 
  at TMPro.TextMeshProUGUI.GenerateTextMesh () [0x00000] in <filename unknown>:0 
  at TMPro.TextMeshProUGUI.Rebuild (CanvasUpdate update) [0x00000] in <filename unknown>:0 
  at UnityEngine.UI.CanvasUpdateRegistry.PerformUpdate () [0x00000] in <filename unknown>:0 
  at UnityEngine.Canvas+WillRenderCanvases.Invoke () [0x00000] in <filename unknown>:0 
UnityEngine.UI.CanvasUpdateRegistry:PerformUpdate()
UnityEngine.WillRenderCanvases:Invoke()
 
(Filename: currently not available on il2cpp Line: -1)
```
Trying different ConvertToUtf32() worked fine for me.

