### PR TITLE
Fixing texture bleeding issues

### DIFF
--- a/Assets/EmojiTexture/TMPro/TMProEmojiAsset.cs
+++ b/Assets/EmojiTexture/TMPro/TMProEmojiAsset.cs
@@ -174,6 +174,14 @@ namespace iBicha.TMPro
         private static TMP_SpriteAsset CreateTMP_SpriteAsset()
         {
             var texture = new Texture2D(SHEET_SIZE, SHEET_SIZE, TextureFormat.RGBA32, false);
+
+            // Fill texture with transparent pixels
+            for (int x = 0; x < SHEET_SIZE; x++) {
+                for (int y = 0; y < SHEET_SIZE; y++) {
+                    texture.SetPixel(x, y, new Color(0, 0, 0, 0));
+                }
+            }
+
             if (EmojiTexture.CanCopyTextures)
             {
                 //If we can copy textures on the GPU, we make it


### PR DESCRIPTION
Empty tiles in emoji spritesheet are filled with gray color that can lead to texture bleeding issues.

<img width="577" alt="screenshot 2018-09-11 13 03 44" src="https://user-images.githubusercontent.com/24836/45353627-006a8b00-b5c4-11e8-9b0f-8fc2b4593ab7.png">

